### PR TITLE
feat: laravel 7 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,11 @@
     ],
     "require": {
         "php": ">=7.2",
-        "illuminate/database": "~5.5|~6",
-        "illuminate/http": "~5.5|~6",
-        "illuminate/routing": "~5.5|~6",
+        "illuminate/database": "~5.5 || ~6.0 || ~7.0",
+        "illuminate/http": "~5.5 || ~6.0 || ~7.0",
+        "illuminate/routing": "~5.5 || ~6.0 || ~7.0",
         "nesbot/carbon": "^1.26.3|^2.0",
-        "quickbooks/v3-php-sdk": "dev-master"
+        "quickbooks/v3-php-sdk": "^5.3.6"
     },
     "require-dev": {
         "mockery/mockery": "^1",


### PR DESCRIPTION
- pin quickbooks version to stable
- use double pipe for version (single is deprecated)
- support laravel 7