### PR TITLE
Feature/add tests and remove alert facade

### DIFF
--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -57,7 +57,7 @@ class Controller extends LaravelController
     {
         $quickbooks->deleteToken();
 
-        $request->session()->flash('success', 'Disconnected to QuickBooks');
+        $request->session()->flash('success', 'Disconnected from QuickBooks');
 
         return $redirector->back();
     }

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -53,13 +53,11 @@ class Controller extends LaravelController
      * @return \Illuminate\Http\RedirectResponse|\Illuminate\View\View
      * @throws \Exception
      */
-    public function disconnect(Redirector $redirector, QuickBooks $quickbooks)
+    public function disconnect(Redirector $redirector, Request $request, QuickBooks $quickbooks)
     {
         $quickbooks->deleteToken();
 
-        // TODO: Figure out where to put this in session & remove Facade
-        Alert::success('Disconnected from QuickBooks')
-             ->flash();
+        $request->session()->flash('success', 'Disconnected to QuickBooks');
 
         return $redirector->back();
     }
@@ -84,7 +82,8 @@ class Controller extends LaravelController
         // TODO: Deal with exceptions
         $quickbooks->exchangeCodeForToken($request->get('code'), $request->get('realmId'));
 
-        return $redirector->intended($url_generator->route('quickbooks.connect'))
-                          ->with('success', 'Connected to QuickBooks');
+        $request->session()->flash('success', 'Connected to QuickBooks');
+
+        return $redirector->intended($url_generator->route('quickbooks.connect'));
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -137,7 +137,7 @@ class ClientTest extends TestCase
     /**
      * @test
      */
-    public function it_returns_a_data_service_with_refreshed_token_when_acccess_token_expired_but_refresh_token_valid()
+    public function it_returns_a_data_service_with_refreshed_token_when_access_token_expired_but_refresh_token_valid()
     {
         $this->expectException(ServiceException::class);
 

--- a/tests/HasQuickBooksTokenTest.php
+++ b/tests/HasQuickBooksTokenTest.php
@@ -36,7 +36,7 @@ class HasQuickBooksTokenTest extends TestCase
      */
     public function it_has_a_hasOne_relationship_to_token()
     {
-        // The stub is just returing the relationship name, so making sure that it is the Token class
+        // The stub is just returning the relationship name, so making sure that it is the Token class
         $this->assertEquals(Token::class, $this->user->quickBooksToken());
     }
 }


### PR DESCRIPTION
Resolving a TODO that removes the dependency on the `Alert` facade. And brings test coverage up to 80%.