### PR TITLE
Lock illuminate/database to patched versions to fix exploit.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
     ],
     "require": {
         "php": ">=7.2",
-        "illuminate/database": "~5.5|~6|~7|~8",
-        "illuminate/http": "~5.5|~6|~7|~8",
-        "illuminate/routing": "~5.5|~6|~7|~8",
-        "nesbot/carbon": "^1.26.3|^2.0",
+        "illuminate/database": "~6.20.4|~7.30.4|~8.24.0",
+        "illuminate/http": "~6|~7|~8",
+        "illuminate/routing": "~6|~7|~8",
+        "nesbot/carbon": "^2.0",
         "quickbooks/v3-php-sdk": "^5.3.6"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": ">=7.2",
-        "illuminate/database": "~6.20.4|~7.30.4|~8.24.0",
+        "illuminate/database": "~6.20.26|~7.30.4|~8.40.0",
         "illuminate/http": "~6|~7|~8",
         "illuminate/routing": "~6|~7|~8",
         "nesbot/carbon": "^2.0",


### PR DESCRIPTION
@jimmypuckett 
There are a couple of high severity exploits in `illuminate/database`. They are patched in Laravel 6, 7, and 8. They are NOT patched in 5.5.

I've locked the illuminate/database versions to the patch numbers at the link below. But I had to drop 5.5 support to do it.

Should we make a new version of this package to only support >= Laravel 6? I think we should b/c 5.5 is not supported.

@see https://github.com/advisories/GHSA-x7p5-p2c9-phvg