### PR TITLE
fix composer2 error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "illuminate/http": "~5.5|~6|~7|~8",
         "illuminate/routing": "~5.5|~6|~7|~8",
         "nesbot/carbon": "^1.26.3|^2.0",
-        "quickbooks/v3-php-sdk": "^5.3.6"
+        "quickbooks/v3-php-sdk": "^6.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.3.1",


### PR DESCRIPTION
Use version 6.0 of the quickbooks sdk to stop composer2 from throwing a psr-4 error